### PR TITLE
Allow for username with numbers when adding users.

### DIFF
--- a/prawtools/mod.py
+++ b/prawtools/mod.py
@@ -36,7 +36,7 @@ class ModUtils(object):
         func = getattr(self.sub, mapping[category])
         print 'Enter user names (any separation should suffice):'
         data = sys.stdin.read().strip()
-        for name in re.split('[^A-Za-z_]+', data):
+        for name in re.split('[^A-Za-z0-9_]+', data):
             func(name)
             print 'Added %r to %s' % (name, category)
 


### PR DESCRIPTION
While trying to do a bulk import for 'contributors' on a new subreddit, I noticed that user names with numbers were being stripped of their numbers and added. This would cause the wrong user to be added, or for the util to throw an exception because the user couldn't be found. This fixes that.
